### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -12971,11 +12971,9 @@ mypep.link
 // Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
 perspecta.cloud
 
-// PE Ulyanov Kirill Sergeevich : https://airy.host
-// Submitted by Kirill Ulyanov <k.ulyanov@airy.host>
+// PE Ulyanov Kirill Sergeevich : https://ditech.dev
+// Submitted by Kirill Ulyanov <k.ulyanov@ditech.dev>
 lk3.ru
-ra-ru.ru
-zsew.ru
 
 // Planet-Work : https://www.planet-work.com/
 // Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [x] Run Syntax Checker (make test)

* [x] Each domain listed in the PRIVATE section has and shall maintain at least two years remaining on registration.

Description of Organization
====

PE Ulyanov Kirill Sergeevich; Hosting

Organization Website: https://ditech.dev/
Old Organization Website: https://airy.host/

Reason for PSL Inclusion
====

Domains under management ditech.dev / airy.host  (lk3.ru) should be listed in the PSL to provide cookie security and to allow password managers to apply the correct password on different subdomains.

.RU domains are registered for not more than 1 year, but domains have been in use for over 2 years.

**The domains ra-ru.ru and zsew.ru will no longer be used and should therefore be removed from the list.** 

DNS Verification via dig
=======



make test
=========

Add merge via web